### PR TITLE
feat: make email address optional when tracking events

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ export default class Vero {
 
   private trackEvent = async (
     userId: string,
-    email: string,
+    email: string | null,
     eventName: string,
     data: Record<string, unknown>
   ): Promise<VeroResponse> => {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -2,7 +2,7 @@ import { VeroResponse } from "./veroResponse";
 
 export type Track = (
   userId: string,
-  email: string,
+  email: string | null,
   eventName: string,
   data: Record<string, unknown>
 ) => Promise<VeroResponse>;


### PR DESCRIPTION
The user's email is not mandatory when tracking an event. Allowing `null` to be passed in.